### PR TITLE
remove empty string values in query params

### DIFF
--- a/studio/src/__tests__/actions/sachFactChecks.js
+++ b/studio/src/__tests__/actions/sachFactChecks.js
@@ -73,32 +73,30 @@ const factcheck = {
 };
 
 describe('sach fact-checks action', () => {
+  // testing the loadingSachFactChecks action
+  it('should create an action to set loading to true', () => {
+    const startLoadingAction = {
+      type: types.SET_SACH_FACT_CHECKS_LOADING,
+      payload: true,
+    };
+    expect(actions.loadingSachFactChecks()).toEqual(startLoadingAction);
+  });
 
-	// testing the loadingSachFactChecks action
-	it('should create an action to set loading to true', () => {
-		const startLoadingAction = {
-			type: types.SET_SACH_FACT_CHECKS_LOADING,
-			payload: true,
-		}
-		expect(actions.loadingSachFactChecks()).toEqual(startLoadingAction)
-	});
+  // testing the stopLoading fact check action
+  it('should create an action to stop loading', () => {
+    const stopLoadingAction = {
+      type: types.SET_SACH_FACT_CHECKS_LOADING,
+      payload: false,
+    };
+    expect(actions.stopLoading()).toEqual(stopLoadingAction);
+  });
 
-	// testing the stopLoading fact check action
-	it('should create an action to stop loading', () => {
-		const stopLoadingAction = {
-			type: types.SET_SACH_FACT_CHECKS_LOADING,
-			payload: false
-		}
-		expect(actions.stopLoading()).toEqual(stopLoadingAction);
-	})
-
-	//testing it addFactChecks action
-	it('should create an action to add fact checks', () => {
-		const addFactChecksAction  = {
-			type: types.ADD_SACH_FACT_CHECKS,
-			payload: [factcheck]
-		};
-		expect(actions.addFactChecks([factcheck])).toEqual(addFactChecksAction);
-	})
+  //testing it addFactChecks action
+  it('should create an action to add fact checks', () => {
+    const addFactChecksAction = {
+      type: types.ADD_SACH_FACT_CHECKS,
+      payload: [factcheck],
+    };
+    expect(actions.addFactChecks([factcheck])).toEqual(addFactChecksAction);
+  });
 });
- 

--- a/studio/src/constants/date.js
+++ b/studio/src/constants/date.js
@@ -1,1 +1,14 @@
-export const listOfMonths = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+export const listOfMonths = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];

--- a/studio/src/pages/categories/index.js
+++ b/studio/src/pages/categories/index.js
@@ -78,7 +78,8 @@ function Categories({ permission }) {
         style={{ width: '100%' }}
         onValuesChange={(changedValues, allValues) => {
           if (!changedValues.q) {
-            setFilters({ ...filters, ...changedValues });
+            const { q, ...filter } = filters;
+            setFilters({ ...filter });
           }
         }}
       >

--- a/studio/src/pages/claimants/index.js
+++ b/studio/src/pages/claimants/index.js
@@ -78,7 +78,8 @@ function Claimants({ permission }) {
         style={{ maxWidth: '100%' }}
         onValuesChange={(changedValues, allValues) => {
           if (!changedValues.q) {
-            setFilters({ ...filters, ...changedValues });
+            const { q, ...filter } = filters;
+            setFilters({ ...filter });
           }
         }}
       >

--- a/studio/src/pages/fact-checks/components/FactCheckForm.js
+++ b/studio/src/pages/fact-checks/components/FactCheckForm.js
@@ -296,9 +296,11 @@ function FactCheckForm({ onCreate, data = {}, actions = {}, format }) {
                   style={{ fontSize: '2.5rem', fontWeight: 'bold', textAlign: 'center' }}
                 />
               </Form.Item>
-              {
-                (data?.updated_at) ? <p style={{fontSize: '18px', color:'#595E60'}}>Last updated on : {getDatefromStringWithoutDay(data.updated_at)}</p> : null
-              }
+              {data?.updated_at ? (
+                <p style={{ fontSize: '18px', color: '#595E60' }}>
+                  Last updated on : {getDatefromStringWithoutDay(data.updated_at)}
+                </p>
+              ) : null}
               {form.getFieldValue('claims') &&
               form.getFieldValue('claims').length > 0 &&
               !loading ? (

--- a/studio/src/pages/media/index.js
+++ b/studio/src/pages/media/index.js
@@ -79,7 +79,8 @@ function Media({ permission }) {
         style={{ width: '100%', marginBottom: '1rem' }}
         onValuesChange={(changedValues, allValues) => {
           if (!changedValues.q) {
-            setFilters({ ...filters, ...changedValues });
+            const { q, ...filter } = filters;
+            setFilters({ ...filter });
           }
         }}
       >

--- a/studio/src/pages/posts/components/PostForm.js
+++ b/studio/src/pages/posts/components/PostForm.js
@@ -236,9 +236,11 @@ function PostForm({ onCreate, data = {}, actions = {}, format, page = false }) {
                   autoSize={{ minRows: 2, maxRows: 6 }}
                 />
               </Form.Item>
-              {
-                (data?.updated_at) ? <p style={{fontSize: '18px', color:'#595E60'}}>Last updated on : {getDatefromStringWithoutDay(data.updated_at)}</p> : null
-              }
+              {data?.updated_at ? (
+                <p style={{ fontSize: '18px', color: '#595E60' }}>
+                  Last updated on : {getDatefromStringWithoutDay(data.updated_at)}
+                </p>
+              ) : null}
               <DescriptionInput
                 type="editor"
                 formItemProps={{ className: 'post-description' }}

--- a/studio/src/pages/tags/index.js
+++ b/studio/src/pages/tags/index.js
@@ -79,7 +79,8 @@ function Tags({ permission }) {
         style={{ width: '100%' }}
         onValuesChange={(changedValues, allValues) => {
           if (!changedValues.q) {
-            setFilters({ ...filters, ...changedValues });
+            const { q, ...filter } = filters;
+            setFilters({ ...filter });
           }
         }}
       >

--- a/studio/src/utils/date.js
+++ b/studio/src/utils/date.js
@@ -1,14 +1,11 @@
-import { listOfMonths } from "../constants/date";
-
+import { listOfMonths } from '../constants/date';
 
 export const getDatefromString = (dateString) => {
   const dateObj = new Date(Date.parse(dateString));
   return dateObj.toDateString();
 };
 
-
 export const getDatefromStringWithoutDay = (dateString) => {
   const dateObj = new Date(Date.parse(dateString));
-  return `${listOfMonths[dateObj.getMonth()]} ${dateObj.getDate()} ${dateObj.getFullYear()}`
+  return `${listOfMonths[dateObj.getMonth()]} ${dateObj.getDate()} ${dateObj.getFullYear()}`;
 };
-


### PR DESCRIPTION
Currently in tags , categories , claimants , media list pages we allow empty strings as search query params . This might resolve #592 . 