### PR TITLE
fix unable to update meta-fields for space 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,7 @@ services:
       - kavach-migrate
     ports:
       - 5001:8000
-    image: factly/kavach-server:0.27.2
+    image: factly/kavach-server:0.27.4
     volumes:
       - type: bind
         source: ./volumes/kavach-server/data
@@ -270,6 +270,7 @@ services:
       - KAVACH_DEFAULT_USER_PASSWORD=Data123@#
       - KAVACH_DEFAULT_ORGANISATION_NAME=NEWSCHECKER
       - KAVACH_ENABLE_IMGPROXY=false
+      - KAVACH_DYNAMIC_EMAIL_ENABLED=true
       - KAVACH_BUCKET_NAME=login.factly.in
     restart: unless-stopped
     networks:
@@ -280,7 +281,7 @@ services:
       - postgres
       - keto
       - kratos
-    image: factly/kavach-server:0.27.2
+    image: factly/kavach-server:0.27.4
     volumes:
       - type: bind
         source: ./volumes/kavach-server/data
@@ -313,13 +314,14 @@ services:
       - KAVACH_DEFAULT_USER_PASSWORD=Data123@#
       - KAVACH_DEFAULT_ORGANISATION_NAME=NEWSCHECKER
       - KAVACH_ENABLE_IMGPROXY=false
+      - KAVACH_DYNAMIC_EMAIL_ENABLED=true
       - KAVACH_BUCKET_NAME=login.factly.in
     entrypoint: ["/bin/sh", "-c" , "/app/kavach-server migrate && /app/kavach-server create-super-org"]
     networks:
       - dega
 
   kavach-web:
-    image: factly/kavach-web:0.27.2-dev
+    image: factly/kavach-web:0.27.4-dev
     volumes:
       - type: bind
         source: ./volumes/kavach-web/config.js

--- a/server/service/core/action/space/create.go
+++ b/server/service/core/action/space/create.go
@@ -181,7 +181,7 @@ func create(w http.ResponseWriter, r *http.Request) {
 	spaceObjectforDega.Name = spaceObjectfromKavach.Name
 	spaceObjectforDega.Slug = spaceObjectfromKavach.Slug
 	spaceObjectforDega.Description = spaceObjectfromKavach.Description
-	spaceObjectforDega.MetaFields = spaceObjectfromKavach.Metadata
+	spaceObjectforDega.MetaFields = spaceObjectfromKavach.MetaFields
 	spaceObjectforDega.ApplicationID = spaceObjectfromKavach.ApplicationID
 	spaceObjectforDega.OrganisationID = int(spaceObjectfromKavach.OrganisationID)
 	spaceObjectforDega.SiteTitle = spaceSettings.SiteTitle

--- a/server/service/core/action/space/my.go
+++ b/server/service/core/action/space/my.go
@@ -153,7 +153,7 @@ func my(w http.ResponseWriter, r *http.Request) {
 			spaceWithPerm.Description = eachSpace.Description
 			spaceWithPerm.ApplicationID = eachSpace.ApplicationID
 			spaceWithPerm.OrganisationID = int(eachSpace.OrganisationID)
-			spaceWithPerm.MetaFields = eachSpace.Metadata
+			spaceWithPerm.MetaFields = eachSpace.MetaFields
 			spaceSettings := model.SpaceSettings{}
 			config.DB.Model(&model.SpaceSettings{}).Where(&model.SpaceSettings{
 				SpaceID: eachSpace.ID,

--- a/server/service/core/action/space/update.go
+++ b/server/service/core/action/space/update.go
@@ -66,7 +66,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
 		return
 	}
-	
+
 	space.ID = uint(spaceID)
 	validationError := validationx.Check(space)
 	if validationError != nil {
@@ -226,6 +226,7 @@ func update(w http.ResponseWriter, r *http.Request) {
 	spaceObjectforDega.Description = spaceObjectfromKavach.Description
 	spaceObjectforDega.ApplicationID = spaceObjectfromKavach.ApplicationID
 	spaceObjectforDega.OrganisationID = int(spaceObjectfromKavach.OrganisationID)
+	spaceObjectforDega.MetaFields = spaceObjectfromKavach.MetaFields
 	spaceSettings := model.SpaceSettings{}
 	config.DB.Model(&model.SpaceSettings{}).Where(&model.SpaceSettings{
 		SpaceID: spaceObjectforDega.ID,

--- a/server/service/core/model/space.go
+++ b/server/service/core/model/space.go
@@ -39,7 +39,7 @@ type KavachSpace struct {
 	Description    string         `json:"description"`
 	ApplicationID  uint           `json:"application_id"`
 	OrganisationID uint           `json:"organisation_id"`
-	Metadata     postgres.Jsonb `json:"meta_fields"`
+	MetaFields     postgres.Jsonb `json:"meta_fields"`
 }
 
 var spaceUser config.ContextKey = "space_user"

--- a/server/util/space.go
+++ b/server/util/space.go
@@ -81,7 +81,7 @@ func GetSpacefromKavach(userID, orgID, spaceID uint) (*Space, error) {
 	spaceObjectforDega.Slug = spaceObjectfromKavach.Slug
 	spaceObjectforDega.Description = spaceObjectfromKavach.Description
 	spaceObjectforDega.ApplicationID = spaceObjectfromKavach.ApplicationID
-	spaceObjectforDega.MetaFields = spaceObjectfromKavach.Metadata
+	spaceObjectforDega.MetaFields = spaceObjectfromKavach.MetaFields
 	spaceSettings := model.SpaceSettings{}
 	config.DB.Model(&model.SpaceSettings{}).Where(&model.SpaceSettings{
 		SpaceID: spaceObjectforDega.ID,


### PR DESCRIPTION
updated kavach to v0.27.4 , as we are currently not able to retrieve meta_fields for spaces from kavach because the current version does not include this change https://github.com/factly/kavach/commit/76aaedc4d1f002ae598151033e24a43f39d50055 where we updated metadata to meta_fields
closes #801

