### PR TITLE
dega-studio : fix media uploads not showing up in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     networks:
       - dega
     entrypoint: >
-      /bin/sh -c " apk add --no-cache bash; wait-for-it.sh minio:9000 -- echo 'Minio is up. Creating the bucket!!'; /usr/bin/mc config host add myminio http://minio:9000 miniokey miniosecret; /usr/bin/mc mb myminio/dega; /usr/bin/mc policy set download myminio/dega; exit 0; "
+      /bin/sh -c " apk add --no-cache bash; wait-for-it.sh minio:9000 -- echo 'Minio is up. Creating the bucket!!'; /usr/bin/mc config host add myminio http://minio:9000 miniokey miniosecret; /usr/bin/mc mb myminio/dega; /usr/bin/mc anonymous set public myminio/dega; exit 0; "
 
   ###########################################################################
   #######                         IFRAMELY                            #######


### PR DESCRIPTION
 in development the media are not showing up as expected, due to the bucket being created with policy as private by default . this pr addresses the issue. 