### PR TITLE
fix: update deprecated GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,23 +8,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Use Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         id: setup_go
         with:
           go-version: "1.18"
       - name: Cache go-modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Login Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u deshetti --password-stdin
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/studio-releaser.yml
+++ b/.github/workflows/studio-releaser.yml
@@ -8,13 +8,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Login Docker Hub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u deshetti --password-stdin
     - name: Build and push dega studio
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         push: true
         tags: factly/dega-studio:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## Summary
- `actions/checkout@v2` → `@v4`
- `actions/cache@v1` → `@v4` (goreleaser.yml)
- `actions/setup-go@v2` → `@v4` (goreleaser.yml)
- `docker/build-push-action@v2` → `@v6` (studio-releaser.yml)
- Added `docker/setup-buildx-action@v3` (required by build-push-action v6)
- `goreleaser/goreleaser-action@v2` → `@v6`

## Why
`actions/cache@v1` and `actions/checkout@v2` use Node.js 20 which is deprecated and will be forced to Node.js 24 by default starting June 2nd, 2026, causing workflow failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment workflows with newer versions of automation tools to enhance system reliability and release process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->