### PR TITLE
fix: update Docker Hub username to gangaprasad2166

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Login Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u deshetti --password-stdin
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u gangaprasad2166 --password-stdin
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/studio-releaser.yml
+++ b/.github/workflows/studio-releaser.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login Docker Hub
-      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u deshetti --password-stdin
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u gangaprasad2166 --password-stdin
     - name: Build and push dega studio
       uses: docker/build-push-action@v6
       with:


### PR DESCRIPTION
## Summary
- Replace hardcoded `deshetti` Docker Hub username with `gangaprasad2166` in both `studio-releaser.yml` and `goreleaser.yml`
- Updated `DOCKER_PASSWORD` secret to use the new PAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. Updates were made to internal build and deployment workflows to maintain infrastructure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->