### PR TITLE
temp: retag workflow for dega-studio stag image testing

### DIFF
--- a/.github/workflows/retag-studio.yml
+++ b/.github/workflows/retag-studio.yml
@@ -1,0 +1,25 @@
+name: Retag Studio Image
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        description: 'Source image to pull (e.g. factly/metafacts-server:0.2.8)'
+        required: true
+        default: 'factly/metafacts-server:0.2.8'
+      target_tag:
+        description: 'Target tag for factly/dega-studio'
+        required: true
+        default: '0.23.0-stag.30'
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u gangaprasad2166 --password-stdin
+      - name: Pull, retag and push
+        run: |
+          docker pull ${{ github.event.inputs.source_image }}
+          docker tag ${{ github.event.inputs.source_image }} factly/dega-studio:${{ github.event.inputs.target_tag }}
+          docker push factly/dega-studio:${{ github.event.inputs.target_tag }}
+          echo "Successfully pushed factly/dega-studio:${{ github.event.inputs.target_tag }}"


### PR DESCRIPTION
Temporary workflow to pull, retag and push dega-studio image for argocd-image-updater testing. To be deleted after testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new GitHub Actions workflow for automated image retagging and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->